### PR TITLE
Backported RTCM subscriber and NMEA GGA publisher from ROS2 driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
   tf2_msgs
   tf2_geometry_msgs
+  mavros_msgs
+  nmea_msgs
 )
 
 ################################################
@@ -56,6 +58,8 @@ generate_messages(DEPENDENCIES
   std_msgs
   nav_msgs
   geometry_msgs
+  mavros_msgs
+  nmea_msgs
 )
 
 ###################################
@@ -72,6 +76,8 @@ catkin_package(
     std_msgs
     std_srvs
     geometry_msgs
+    mavros_msgs
+    nmea_msgs
 )
 
 ###########
@@ -98,6 +104,7 @@ include_directories(
 set (SBG_COMMON_RESOURCES
   src/config_applier.cpp
   src/message_publisher.cpp
+  src/message_subscriber.cpp
   src/message_wrapper.cpp
   src/config_store.cpp
   src/sbg_device.cpp

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ Launch the sbg_device_mag node to calibrate the magnetometers, and load the `ell
 
 ## Nodes
 ### sbg_device
-The sbg_device node handles the communication with the connected device, and publishes the SBG output to the Ros environment.
+The `sbg_device` node handles the communication with the connected device, and publishes the SBG output to the Ros environment.
+
+### sbg_subscriber
+The `sbg_subscriber` node handles the subscriptions to the Ros environment topics, and forward data the device.  
 
 #### Published Topics
 ##### SBG specific topics
@@ -207,6 +210,24 @@ For each ROS standard, you have to activate the needed SBG outputs.
   UTM projected position relative to the first valid INS position.
   Requires `/sbg/imu_data` and `/sbg/ekv_nav` and either `/sbg/ekf_euler` or `/sbg/ekf_quat`.
   Disabled by default, set odometry.enable in configuration file.
+
+##### NMEA topics
+GPS data in NMEA format can be published when `publish_nmea` is set to `true` in .yaml config file.  
+Data published on that topic can be used by a third party ROS module for NTRIP purpose.
+
+* **`/ntrip_client/nmea`** [nmea_msgs/Sentence](http://docs.ros.org/en/api/nmea_msgs/html/msg/Sentence.html)
+
+  Data from `/sbg/gps_pos` serialized into NMEA GGA format. Requires `/sbg/gps_pos`.  
+  Namespace `ntrip_client` and topic_name `nmea` can be customized in .yaml config files.
+
+#### Subscribed Topics
+##### RTCM topics
+SBG ROS Driver will listen to some topics published by third party ROS modules.
+
+* **`/ntrip_client/rtcm`** [mavros_msgs/RTCM](http://docs.ros.org/en/noetic/api/mavros_msgs/html/msg/RTCM.html)
+
+  RTCM data from `/ntrip_client/rtcm` will be forwarded to the IMU.    
+  Namespace `ntrip_client` and topic_name `rtcm` can be customized in .yaml config files.
 
 ### sbg_device_mag
 The sbg_device_mag node handles the magnetic calibration for suitable devices.

--- a/config/sbg_device_uart_default.yaml
+++ b/config/sbg_device_uart_default.yaml
@@ -290,3 +290,19 @@ output:
   log_air_data: 0
   # Short IMU data
   log_imu_short: 8
+
+rtcm:
+  # Should ros driver listen to RTCM topic
+  listen_rtcm: false
+  # Topic on which RTCM is published
+  topic_name: rtcm
+  # Namespace where topic is published
+  namespace: ntrip_client
+
+nmea:
+  # Should ros driver publish NMEA string
+  publish_nmea: false
+  # Topic on which to publish nmea data
+  topic_name: nmea
+  # Namespace where to publish topic
+  namespace: ntrip_client

--- a/config/sbg_device_udp_default.yaml
+++ b/config/sbg_device_udp_default.yaml
@@ -282,3 +282,19 @@ output:
   log_air_data: 0
   # Short IMU data
   log_imu_short: 0
+
+rtcm:
+  # Should ros driver listen to RTCM topic
+  listen_rtcm: false
+  # Topic on which RTCM is published
+  topic_name: rtcm
+  # Namespace where topic is published
+  namespace: ntrip_client
+
+nmea:
+  # Should ros driver publish NMEA string
+  publish_nmea: false
+  # Topic on which to publish nmea data
+  topic_name: nmea
+  # Namespace where to publish topic
+  namespace: ntrip_client

--- a/include/sbg_driver/config_store.h
+++ b/include/sbg_driver/config_store.h
@@ -121,6 +121,16 @@ private:
   std::string                 m_odom_base_frame_id_;
   std::string                 m_odom_init_frame_id_;
 
+  bool                        m_listen_rtcm_;
+  std::string                 m_rtcm_topic_name_;
+  std::string                 m_rtcm_topic_namespace_;
+  std::string                 m_rtcm_full_topic_;
+
+  bool                        m_publish_nmea_;
+  std::string                 m_nmea_topic_name_;
+  std::string                 m_nmea_topic_namespace_;
+  std::string                 m_nmea_full_topic_;
+
   //---------------------------------------------------------------------//
   //- Private  methods                                                  -//
   //---------------------------------------------------------------------//
@@ -238,6 +248,20 @@ private:
    * \param[in] ref_key           String key for the output config.
    */
   void loadOutputTimeReference(const ros::NodeHandle& ref_node_handle, const std::string& ref_key);
+
+  /*!
+   * Load RTCM parameters.
+   *
+   * \param[in] ref_node_handle   ROS nodeHandle.
+   */
+  void loadRtcmParameters(const ros::NodeHandle& ref_node_handle);
+
+  /*!
+   * Load NMEA parameters.
+   *
+   * \param[in] ref_node_handle   ROS nodeHandle.
+   */
+  void loadNmeaParameters(const ros::NodeHandle& ref_node_handle);
 
 public:
 
@@ -456,21 +480,21 @@ public:
    *
    * \return					 True if the frame convention to use is ENU.
    */
-   bool getUseEnu(void) const;
+  bool getUseEnu(void) const;
 
   /*!
    * Get odom enable.
    *
    * \return					 True if the odometry is enabled.
    */
-   bool getOdomEnable(void) const;
+  bool getOdomEnable(void) const;
 
   /*!
    * Get odom publish_tf.
    *
    * \return					 If true publish odometry transforms.
    */
-   bool getOdomPublishTf(void) const;
+  bool getOdomPublishTf(void) const;
 
   /*!
    * Get the odometry frame ID.
@@ -501,6 +525,34 @@ public:
    * \return                      Time reference.
    */
   TimeReference getTimeReference(void) const;
+
+  /*!
+   * Get RTCM enable.
+   *
+   * \return                      True if RTCM is enabled.
+   */
+  bool shouldListenRtcm(void) const;
+
+  /*!
+   * Get RTCM full topic.
+   *
+   * \return                      String with RTCM namespace + topic.
+   */
+  const std::string &getRtcmFullTopic(void) const;
+
+  /*!
+   * Get NMEA enable.
+   *
+   * \return                      True if NMEA is enabled.
+   */
+  bool shouldPublishNmea() const;
+
+  /*!
+   * Get NMEA full topic.
+   *
+   * \return                      String with NMEA namespace + topic.
+   */
+  const std::string &getNmeaFullTopic(void) const;
 
   //---------------------------------------------------------------------//
   //- Operations                                                        -//

--- a/include/sbg_driver/message_publisher.h
+++ b/include/sbg_driver/message_publisher.h
@@ -82,6 +82,8 @@ private:
   ros::Publisher          m_nav_sat_fix_pub_;
   ros::Publisher          m_odometry_pub_;
 
+  ros::Publisher          m_sbgGpsPos_gga_pub_;
+
   MessageWrapper          m_message_wrapper_;
   uint32_t                m_max_messages_;
   std::string             m_frame_id_;
@@ -170,8 +172,9 @@ private:
    * Publish a received SBG GpsPos log.
    *
    * \param[in] ref_sbg_log             SBG log.
+   * \param[in] sbg_msg_id              Id of the SBG message.
    */
-  void publishGpsPosData(const SbgBinaryLogData &ref_sbg_log);
+  void publishGpsPosData(const SbgBinaryLogData &ref_sbg_log, SbgEComMsgId sbg_msg_id);
 
 public:
 

--- a/include/sbg_driver/message_subscriber.h
+++ b/include/sbg_driver/message_subscriber.h
@@ -1,0 +1,89 @@
+/*!
+*	\file         message_subscriber.h
+*	\author       SBG Systems
+*	\date         26/05/2023
+*
+*	\brief        Manage subscription of messages.
+*
+*	\section CodeCopyright Copyright Notice
+*	MIT License
+*
+*	Copyright (c) 2023 SBG Systems
+*
+*	Permission is hereby granted, free of charge, to any person obtaining a copy
+*	of this software and associated documentation files (the "Software"), to deal
+*	in the Software without restriction, including without limitation the rights
+*	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*	copies of the Software, and to permit persons to whom the Software is
+*	furnished to do so, subject to the following conditions:
+*
+*	The above copyright notice and this permission notice shall be included in all
+*	copies or substantial portions of the Software.
+*
+*	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*	SOFTWARE.
+*/
+
+#ifndef SBG_ROS_MESSAGE_SUBSCRIBER_H
+#define SBG_ROS_MESSAGE_SUBSCRIBER_H
+
+// Project headers
+#include <config_store.h>
+#include <mavros_msgs/RTCM.h>
+
+namespace sbg
+{
+/*!
+ * Class to subscribe to all corresponding topics.
+ */
+class MessageSubscriber: public ros::NodeHandle
+{
+private:
+
+  ros::Subscriber         m_rtcm_sub_;
+
+  uint32_t                m_max_messages_;
+  SbgInterface            *m_sbg_interface_;
+
+  //---------------------------------------------------------------------//
+  //- Private methods                                                   -//
+  //---------------------------------------------------------------------//
+  /*!
+   * Handler for subscription to RTCM topic.
+   *
+   * \param[in] msg             ROS RTCM message.
+   */
+  void readRosRtcmMessage(const mavros_msgs::RTCM::ConstPtr& msg) const;
+
+public:
+
+  //---------------------------------------------------------------------//
+  //- Constructor                                                       -//
+  //---------------------------------------------------------------------//
+
+  /*!
+   * Default constructor.
+   *
+   * \param[in] sbg_interface   SBG Interface handle.
+   */
+  MessageSubscriber(SbgInterface *sbg_interface);
+
+  //---------------------------------------------------------------------//
+  //- Operations                                                        -//
+  //---------------------------------------------------------------------//
+
+  /*!
+   * Initialize the subscribers with configuration.
+   *
+   * \param[in] ref_config_store        Store configuration for the subscribers.
+   */
+  void initTopicSubscriptions(const ConfigStore &ref_config_store);
+};
+}
+
+#endif // SBG_ROS_MESSAGE_SUBSCRIBER_H

--- a/include/sbg_driver/message_wrapper.h
+++ b/include/sbg_driver/message_wrapper.h
@@ -56,6 +56,7 @@
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <nav_msgs/Odometry.h>
+#include <nmea_msgs/Sentence.h>
 
 // SbgRos message headers
 #include "sbg_driver/SbgStatus.h"
@@ -85,6 +86,19 @@ typedef struct _UTM0
 	double			altitude;
 	int				zone;
 } UTM0;
+
+typedef enum _SbgNmeaGpsQuality
+{
+    SBG_NMEA_GPS_QUALITY_INVALID	            = 0,
+    SBG_NMEA_GPS_QUALITY_SINGLE	                = 1,
+    SBG_NMEA_GPS_QUALITY_DGPS	                = 2,
+    SBG_NMEA_GPS_QUALITY_PPS		            = 3,
+    SBG_NMEA_GPS_QUALITY_RTK	            	= 4,
+    SBG_NMEA_GPS_QUALITY_RTK_FLOAT	           	= 5,
+    SBG_NMEA_GPS_QUALITY_FIX_DEAD_RECKONING		= 6,
+    SBG_NMEA_GPS_QUALITY_MANUAL_INPUT	    	= 7,
+    SBG_NMEA_GPS_QUALITY_SIMULATED		        = 8,
+} SbgNmeaGpsQuality;
 
 /*!
  * Class to wrap the SBG logs into ROS messages.
@@ -291,26 +305,26 @@ private:
    * \param[in] ref_pose                Pose.
    * \param[out] ref_transform_stamped  Stamped transformation.
    */
-   void fillTransform(const std::string &ref_parent_frame_id, const std::string &ref_child_frame_id, const geometry_msgs::Pose &ref_pose, geometry_msgs::TransformStamped &ref_transform_stamped);
+  void fillTransform(const std::string &ref_parent_frame_id, const std::string &ref_child_frame_id, const geometry_msgs::Pose &ref_pose, geometry_msgs::TransformStamped &ref_transform_stamped);
 
-   /*!
+  /*!
    * Get UTM letter designator for the given latitude.
    *
    * \param[in] Lat                     Latitude, in degrees.
    * \return                            UTM letter designator.
    */
-   char UTMLetterDesignator(double Lat);
+  char UTMLetterDesignator(double Lat);
 
-   /*!
+  /*!
    * Set UTM initial position.
    *
    * \param[in] Lat                     Latitude, in degrees.
    * \param[in] Long                    Longitude, in degrees.
    * \param[in] altitude                Altitude, in meters.
    */
-   void initUTM(double Lat, double Long, double altitude);
+  void initUTM(double Lat, double Long, double altitude);
 
-   /*!
+  /*!
    * Convert latitude and longitude to a position relative to UTM initial position.
    *
    * \param[in] Lat                     Latitude, in degrees.
@@ -319,7 +333,15 @@ private:
    * \param[out] UTMNorthing            UTM northing, in meters.
    * \param[out] UTMEasting             UTM easting, in meters.
    */
-   void LLtoUTM(double Lat, double Long, int zoneNumber, double &UTMNorthing, double &UTMEasting) const;
+  void LLtoUTM(double Lat, double Long, int zoneNumber, double &UTMNorthing, double &UTMEasting) const;
+
+  /*!
+   * Convert SbgEComGpsPosType enum to SbgNmeaGpsQuality enum
+   *
+   * \param[in] sbgGpsType              SbgECom GPS type
+   * \return                            NMEA GPS type
+   */
+  static SbgNmeaGpsQuality convertSbgGpsTypeToNmeaGpsType(SbgEComGpsPosType sbgGpsType);
 
 public:
 
@@ -640,6 +662,14 @@ public:
    * \return                        ROS standard fluid pressure message.
    */
   const sensor_msgs::FluidPressure createRosFluidPressureMessage(const sbg_driver::SbgAirData& ref_sbg_air_msg) const;
+
+  /*!
+   * Create a SBG-ROS GPS-Position message.
+   *
+   * \param[in] ref_log_gps_pos     SBG GPS Position log.
+   * \return                        GPS Position message in nmea format.
+   */
+  const nmea_msgs::Sentence createSbgGpsPosMessageGGA(const SbgLogGpsPos& ref_log_gps_pos) const;
 };
 }
 

--- a/include/sbg_driver/sbg_device.h
+++ b/include/sbg_driver/sbg_device.h
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <thread>
 
 // ROS headers
 #include <std_srvs/SetBool.h>
@@ -47,6 +48,7 @@
 #include <config_applier.h>
 #include <config_store.h>
 #include <message_publisher.h>
+#include <message_subscriber.h>
 
 namespace sbg
 {
@@ -70,19 +72,20 @@ private:
   //- Private variables                                                 -//
   //---------------------------------------------------------------------//
 
-  SbgEComHandle           m_com_handle_;
-  SbgInterface            m_sbg_interface_;
-  ros::NodeHandle&        m_ref_node_;
-  MessagePublisher        m_message_publisher_;
-  ConfigStore             m_config_store_;
+  SbgEComHandle                             m_com_handle_;
+  SbgInterface                              m_sbg_interface_;
+  ros::NodeHandle&                          m_ref_node_;
+  MessagePublisher                          m_message_publisher_;
+  std::shared_ptr<MessageSubscriber>        m_message_subscriber_;
+  ConfigStore                               m_config_store_;
 
-  uint32_t                m_rate_frequency_;
+  uint32_t                                  m_rate_frequency_;
 
-  bool                    m_mag_calibration_ongoing_;
-  bool                    m_mag_calibration_done_;
-  SbgEComMagCalibResults  m_magCalibResults;
-  ros::ServiceServer      m_calib_service_;
-  ros::ServiceServer      m_calib_save_service_;
+  bool                                      m_mag_calibration_ongoing_;
+  bool                                      m_mag_calibration_done_;
+  SbgEComMagCalibResults                    m_magCalibResults;
+  ros::ServiceServer                        m_calib_service_;
+  ros::ServiceServer                        m_calib_save_service_;
 
   //---------------------------------------------------------------------//
   //- Private  methods                                                  -//
@@ -140,6 +143,11 @@ private:
    * Initialize the publishers according to the configuration.
    */
   void initPublishers(void);
+
+  /*!
+   * Initialize the subscribers according to the configuration.
+   */
+  void initSubscribers(void);
 
   /*!
    * Configure the connected SBG device.

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,8 @@
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_msgs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>mavros_msgs</build_depend>
+  <build_depend>nmea_msgs</build_depend>
   
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -34,5 +36,7 @@
   <run_depend>tf2_ros</run_depend>
   <run_depend>tf2_msgs</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>mavros_msgs</run_depend>
+  <run_depend>nmea_msgs</run_depend>
   
 </package>

--- a/src/config_store.cpp
+++ b/src/config_store.cpp
@@ -14,7 +14,9 @@ ConfigStore::ConfigStore(void):
 m_serial_communication_(false),
 m_upd_communication_(false),
 m_configure_through_ros_(false),
-m_ros_standard_output_(false)
+m_ros_standard_output_(false),
+m_listen_rtcm_(false),
+m_publish_nmea_(false)
 {
 
 }
@@ -190,6 +192,25 @@ void ConfigStore::loadOutputTimeReference(const ros::NodeHandle& ref_node_handle
     throw std::invalid_argument("unknown time reference: " + time_reference);
   }
 }
+
+
+void ConfigStore::loadRtcmParameters(const ros::NodeHandle &ref_node_handle)
+{
+    ref_node_handle.param<bool>("rtcm/listen_rtcm", m_listen_rtcm_, false);
+    ref_node_handle.param<std::string>("rtcm/topic_name", m_rtcm_topic_name_, "rtcm");
+    ref_node_handle.param<std::string>("rtcm/namespace", m_rtcm_topic_namespace_, "ntrip_client");
+    m_rtcm_full_topic_ = m_rtcm_topic_namespace_ + "/" + m_rtcm_topic_name_;
+}
+
+void ConfigStore::loadNmeaParameters(const ros::NodeHandle &ref_node_handle)
+{
+    ref_node_handle.param<bool>("nmea/publish_nmea", m_publish_nmea_, false);
+    ref_node_handle.param<std::string>("nmea/topic_name", m_nmea_topic_name_, "nmea");
+    ref_node_handle.param<std::string>("nmea/namespace", m_nmea_topic_namespace_, "ntrip_client");
+    m_nmea_full_topic_ = m_nmea_topic_namespace_ + "/" + m_nmea_topic_name_;
+}
+
+
 
 //---------------------------------------------------------------------//
 //- Parameters                                                        -//
@@ -370,6 +391,26 @@ const std::string &ConfigStore::getOdomInitFrameId(void) const
   return m_odom_init_frame_id_;
 }
 
+bool ConfigStore::shouldListenRtcm(void) const
+{
+    return m_listen_rtcm_;
+}
+
+const std::string &sbg::ConfigStore::getRtcmFullTopic(void) const
+{
+    return m_rtcm_full_topic_;
+}
+
+bool ConfigStore::shouldPublishNmea(void) const
+{
+    return m_publish_nmea_;
+}
+
+const std::string &ConfigStore::getNmeaFullTopic(void) const
+{
+    return m_nmea_full_topic_;
+}
+
 //---------------------------------------------------------------------//
 //- Operations                                                        -//
 //---------------------------------------------------------------------//
@@ -386,6 +427,8 @@ void ConfigStore::loadFromRosNodeHandle(const ros::NodeHandle& ref_node_handle)
   loadGnssParameters(ref_node_handle);
   loadOdometerParameters(ref_node_handle);
   loadOutputFrameParameters(ref_node_handle);
+  loadRtcmParameters(ref_node_handle);
+  loadNmeaParameters(ref_node_handle);
 
   loadOutputTimeReference(ref_node_handle, "output/time_reference");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ int main(int argc, char **argv)
       loop_rate.sleep();
     }
 
+    ros::shutdown();
     return 0;
   }
   catch (ros::Exception const& refE)

--- a/src/message_subscriber.cpp
+++ b/src/message_subscriber.cpp
@@ -1,0 +1,53 @@
+#include "message_subscriber.h"
+
+// ROS headers
+#include <ros/ros.h>
+
+// SBG headers
+#include <interfaces/sbgInterface.h>
+
+using sbg::MessageSubscriber;
+
+/*!
+ * Class to publish all SBG-ROS messages to the corresponding publishers. 
+ */
+//---------------------------------------------------------------------//
+//- Constructor                                                       -//
+//---------------------------------------------------------------------//
+
+MessageSubscriber::MessageSubscriber(SbgInterface *sbg_interface): NodeHandle("sbg_subscriber"),
+m_max_messages_(10), m_sbg_interface_(sbg_interface)
+{
+}
+
+//---------------------------------------------------------------------//
+//- Private methods                                                   -//
+//---------------------------------------------------------------------//
+
+void MessageSubscriber::readRosRtcmMessage(const mavros_msgs::RTCM::ConstPtr& msg) const
+{
+    assert(m_sbg_interface_);
+
+    auto rtcm_data = msg->data;
+    auto error_code = sbgInterfaceWrite(m_sbg_interface_, rtcm_data.data(), rtcm_data.size());
+    if (error_code != SBG_NO_ERROR)
+    {
+        char error_str[256];
+
+        sbgEComErrorToString(error_code, error_str);
+        SBG_LOG_ERROR(SBG_ERROR, "Failed to sent RTCM data to device: %s", error_str);
+    }
+
+}
+
+//---------------------------------------------------------------------//
+//- Operations                                                        -//
+//---------------------------------------------------------------------//
+
+void MessageSubscriber::initTopicSubscriptions(const ConfigStore &ref_config_store)
+{
+    if (ref_config_store.shouldListenRtcm())
+    {
+        m_rtcm_sub_ = subscribe("/" + ref_config_store.getRtcmFullTopic(), m_max_messages_, &MessageSubscriber::readRosRtcmMessage, this);
+    }
+}

--- a/src/sbg_device.cpp
+++ b/src/sbg_device.cpp
@@ -201,6 +201,21 @@ void SbgDevice::initPublishers(void)
   m_rate_frequency_ = m_config_store_.getReadingRateFrequency();
 }
 
+
+void SbgDevice::initSubscribers(void)
+{
+    if (!m_config_store_.shouldListenRtcm())
+    {
+        return;
+    }
+
+    m_message_subscriber_ = std::make_shared<MessageSubscriber>(&m_sbg_interface_);
+    m_message_subscriber_->initTopicSubscriptions(m_config_store_);
+    std::thread([&]{
+        ros::spin();
+    }).detach();
+}
+
 void SbgDevice::configure(void)
 {
   if (m_config_store_.checkConfigWithRos())
@@ -462,6 +477,7 @@ void SbgDevice::initDeviceForReceivingData(void)
 {
   SbgErrorCode error_code;
   initPublishers();
+  initSubscribers();
   configure();
 
   error_code = sbgEComSetReceiveLogCallback(&m_com_handle_, onLogReceivedCallback, this);


### PR DESCRIPTION
In order to support a third party NTRIP client ROS module, an RTCM subscriber and NMEA GGA publisher were added.  
Those changes were backported from ROS2 driver.